### PR TITLE
Fix 404 url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To get a local copy up and running follow these simple steps.
 
 ## Roadmap
 
-See the [open issues](https://github.com/opeik/runback_name/issues) for a list of proposed features (and known issues).
+See the [open issues](https://github.com/opeik/runback/issues) for a list of proposed features (and known issues).
 
 ## Contributing
 


### PR DESCRIPTION
Fixes URL in *Roadmap* section of readme so that it correctly links to issues page 